### PR TITLE
Tiny typo fixes for http-rust hub

### DIFF
--- a/content/hub/template_http_rust.md
+++ b/content/hub/template_http_rust.md
@@ -11,12 +11,12 @@ category = "Template"
 language = "Rust"
 created_at = "2022-10-15T00:22:56Z"
 last_updated = "2022-10-15T00:22:56Z"
-spin_version = ">v0.1"
-summary =  "A template to create an HTTP-handler in Rust"
+spin_version = ">v0.2"
+summary =  "A template to create an HTTP handler in Rust"
 url = "https://github.com/fermyon/spin/tree/main/templates/http-rust"
 
 ---
 
-This is the default HTTP trigger template for Rust. It installs by default with the [Spin Install script](https://developer.fermyon.com/spin/install#installing-spin).
+This is the default HTTP trigger template for Rust. It installs by default with the [Spin install script](https://developer.fermyon.com/spin/install#installing-spin).
 
 This guide walks you through how to use it: [HTTP Components](https://developer.fermyon.com/spin/rust-components#http-components)


### PR DESCRIPTION
Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title, `template`, and `date` are all set
- [ ] Does this PR have a new menu item (anywhere in `templates/*.hbs` files) that points to a document `.md` that is set to publish in the future? If so please only publish the `.md` and `.hbs` changes in real-time (otherwise there will be a menu item pointing to a `.md` file that does not exist)
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [ ] Has passed [`bart check`](https://developer.fermyon.com/bartholomew/quickstart)
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
- [ ] Relates to an existing (potentially outdated) blog article? If so please add URL in blog to point to this content.
